### PR TITLE
add option to use a different Host key for CORS checks

### DIFF
--- a/jupyterhub/apihandlers/base.py
+++ b/jupyterhub/apihandlers/base.py
@@ -39,7 +39,7 @@ class APIHandler(BaseHandler):
 
         - allow unspecified host/referer (e.g. scripts)
         """
-        host = self.request.headers.get("Host")
+        host = self.request.headers.get(self.app.forwarded_host_header or "Host")
         referer = self.request.headers.get("Referer")
 
         # If no header is provided, assume it comes from a script/curl.

--- a/jupyterhub/app.py
+++ b/jupyterhub/app.py
@@ -711,6 +711,16 @@ class JupyterHub(Application):
             self.proxy_api_ip or '127.0.0.1', self.proxy_api_port or self.port + 1
         )
 
+    forwarded_host_header = Unicode(
+        '',
+        help="""Alternate header to use as the Host (e.g., X-Forwarded-Host)
+        when determining whether a request is cross-origin
+
+        This may be useful when JupyterHub is running behind a proxy that rewrites
+        the Host header.
+        """,
+    ).tag(config=True)
+
     hub_port = Integer(
         8081,
         help="""The internal port for the Hub process.

--- a/jupyterhub/tests/test_api.py
+++ b/jupyterhub/tests/test_api.py
@@ -107,6 +107,28 @@ async def test_referer_check(app):
     )
     assert r.status_code == 200
 
+    app.forwarded_host_header = 'X-Forwarded-Host'
+    r = await api_request(
+        app,
+        'users',
+        headers={
+            'Authorization': '',
+            'Referer': url,
+            'Host': host,
+            'X-Forwarded-Host': 'example.com',
+        },
+        cookies=cookies,
+    )
+    assert r.status_code == 403
+
+    r = await api_request(
+        app,
+        'users',
+        headers={'Authorization': '', 'Referer': url, 'X-Forwarded-Host': host},
+        cookies=cookies,
+    )
+    assert r.status_code == 200
+
 
 # --------------
 # User API tests


### PR DESCRIPTION
The `check_referer` method checks that the Host header and Referer header are from the same location. In our case, Istio rewrites the host to the Kubernetes internal url (x.y.svc.cluster.local) instead of the externally visible URL (jupyterhub.mydomain.com). 

The original host is preserved in the X-Forwarded-Host header, and can be used to confirm the correct origin.